### PR TITLE
Changes for Text Rendering

### DIFF
--- a/luna-gfx/ext/math.hpp
+++ b/luna-gfx/ext/math.hpp
@@ -171,22 +171,18 @@ struct vec3_t {
 template<typename T>
 struct vec2_t {
   vec2_t() = default;
-  vec2_t(T r, T g) : values{r, g} {};
+  vec2_t(T r, T g) : x(r), y(g) {};
+  T x, y;
 
-  union {
-    T x, y;
-    T values[2];
-  };
-
+  
   constexpr auto length() const {return 2u;}
-  [[nodiscard]] auto operator[](std::size_t index) const -> const T& {return values[index];}
-  [[nodiscard]] auto operator[](std::size_t index) -> T& {return values[index];}
+  [[nodiscard]] auto operator[](std::size_t index) const -> const T& {return *(reinterpret_cast<const T*>(this) + index);}
+  [[nodiscard]] auto operator[](std::size_t index) -> T& {return *(reinterpret_cast<T*>(this) + index);}
 
   template<typename G>
   auto operator==(const G& cmp) const -> bool {
-    for(auto i = 0u; i < length(); ++i) {
-      if(values[i] != cmp[i]) return false;
-    }
+    if(this->x != cmp.x) return false;
+    if(this->y != cmp.y) return false;
     return true;
   }
 
@@ -239,9 +235,8 @@ struct vec2_t {
   // We can become any type.
   template<typename G>
   auto operator=(const G& cpy) -> vec2_t& {
-    for(auto i = 0u; i < length(); ++i) {
-      values[i] = cpy[i];
-    }
+    this->x = cpy.x;
+    this->y = cpy.y;
     return *this;
   }
 };
@@ -379,6 +374,9 @@ using vec4 = vec4_t<float>;
 using vec3 = vec3_t<float>;
 using vec2 = vec2_t<float>;
 
+using ivec4 = vec4_t<int>;
+using ivec3 = vec3_t<int>;
+using ivec2 = vec2_t<int>;
 static_assert(sizeof(mat4) == sizeof(float) * 16);
 static_assert(sizeof(vec4) == sizeof(float) * 4);
 static_assert(sizeof(vec3) == sizeof(float) * 3);

--- a/luna-gfx/interface/buffer.hpp
+++ b/luna-gfx/interface/buffer.hpp
@@ -92,9 +92,10 @@ public:
   Vector(const Vector& cpy) = delete;
   ~Vector() = default;
   auto operator=(const Vector& cpy) -> Vector& = delete;
-  auto operator=(Vector&& mv) -> Vector& = default  ;
+  auto operator=(Vector&& mv) -> Vector& = default;
   [[nodiscard]] inline auto size() const -> std::size_t {return this->m_data.size() / sizeof(T);}
   [[nodiscard]] inline auto get_mapped_container() -> MappedBuffer<T> {return this->m_data.get_mapped_container<T>();}
+  [[nodiscard]] inline auto empty() const -> bool {return this->size() == 0;}
   inline auto flush() -> void {this->m_data.flush();}
   inline auto upload(const T* ptr, std::size_t amt) -> void {this->m_data.upload(ptr, amt);}
   inline auto upload(const T* ptr) -> void {this->m_data.upload(ptr, this->size());}
@@ -116,6 +117,7 @@ private:
 
 auto unmap_mapped_buffer(std::int32_t handle) -> void;
 
+// RAII Memory buffer. Unmaps on deconstruction. Iteratable & usable with std::algorithms.
 template<typename T>
 class MappedBuffer {
 public:

--- a/luna-gfx/interface/event.cpp
+++ b/luna-gfx/interface/event.cpp
@@ -1,4 +1,5 @@
 #include "luna-gfx/interface/event.hpp"
+#include "luna-gfx/error/error.hpp"
 #include <SDL2/SDL.h>
 #include <utility>
 namespace luna {
@@ -203,7 +204,10 @@ auto convert(SDL_Event& event) -> Event {
       lib_event = Event(Event::Type::WindowExit, Key::ESC);
       break;
     }
-    default:;
+    case SDL_TEXTINPUT:
+      lib_event = Event(Event::Type::Text, std::string(event.text.text));
+      break;
+    default: break;
   }
 
   return lib_event;
@@ -249,6 +253,19 @@ auto poll_events() -> void {
       cb(c);
     }
   }
+}
+
+auto get_mouse_position() -> std::pair<int, int> {
+  auto x = 0, y = 0;
+  SDL_GetMouseState(&x, &y);
+  return {x, y};
+}
+auto enable_text_input() -> void {
+  SDL_StartTextInput();
+}
+
+auto disable_text_input() -> void {
+  SDL_StopTextInput();
 }
 }
 }  // namespace luna

--- a/luna-gfx/interface/event.hpp
+++ b/luna-gfx/interface/event.hpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <string_view>
+#include <utility> // for pair
 namespace luna {
 namespace gfx {
 class Event;
@@ -112,6 +114,7 @@ class Event {
     None,
     KeyDown,
     KeyUp,
+    Text,
     MouseButtonDown,
     MouseButtonUp,
     MouseWheelUp,
@@ -125,16 +128,18 @@ class Event {
   inline Event();
   inline Event(Event::Type type, Key key);
   inline Event(Event::Type type, MouseButton button);
+  inline Event(Event::Type type, std::string text);
   inline Event(const Event& event);
   inline ~Event() = default;
   [[nodiscard]] inline auto type() const -> Type;
   [[nodiscard]] inline auto key() const -> Key;
   [[nodiscard]] inline auto button() const -> MouseButton;
-
+  [[nodiscard]] inline auto string() const -> std::string_view;
  private:
   Type event_type;
   Key event_key;
   MouseButton event_button;
+  std::string event_string;
 };
 
 [[nodiscard]] inline static auto to_string(const Event::Type& event) -> std::string;
@@ -158,6 +163,10 @@ class EventRegister {
   std::unique_ptr<EventRegisterData> m_data;
 };
 
+                                      // x and y
+auto get_mouse_position() -> std::pair<int, int>;
+auto enable_text_input() -> void;
+auto disable_text_input() -> void;
 auto poll_events() -> void;
 
 Event::Event(Event::Type type, Key key) {
@@ -170,6 +179,11 @@ Event::Event(Event::Type type, MouseButton button) {
   this->event_button = button;
 }
 
+Event::Event(Event::Type type, std::string in_str) {
+  this->event_type = type;
+  this->event_string = in_str;
+}
+
 Event::Event() {
   this->event_type = Event::Type::None;
   this->event_button = MouseButton::None;
@@ -179,13 +193,13 @@ Event::Event() {
 Event::Event(const Event& event) {
   this->event_key = event.event_key;
   this->event_type = event.event_type;
+  this->event_string = event.event_string;
 }
 
-auto Event::button() const -> MouseButton { return this->event_button; }
-
-auto Event::type() const -> Event::Type { return this->event_type; }
-
-auto Event::key() const -> Key { return this->event_key; }
+auto Event::button() const -> MouseButton {return this->event_button;}
+auto Event::string() const -> std::string_view {return this->event_string;}
+auto Event::type() const -> Event::Type {return this->event_type;}
+auto Event::key() const -> Key {return this->event_key;}
 
 auto to_string(const Event& event) -> std::string {
   switch (event.type()) {

--- a/luna-gfx/vulkan/utils/helper_functions.hpp
+++ b/luna-gfx/vulkan/utils/helper_functions.hpp
@@ -20,6 +20,7 @@ inline auto convert(luna::gfx::ImageFormat fmt) -> vk::Format {
     case gfx::ImageFormat::BGRA8: return vk::Format::eB8G8R8A8Srgb;
     case gfx::ImageFormat::RGBA32F: return vk::Format::eR32G32B32A32Sfloat;
     case gfx::ImageFormat::Depth: return vk::Format::eD24UnormS8Uint;
+    case gfx::ImageFormat::R8: return vk::Format::eR8Srgb;
     default: return vk::Format::eR8G8B8A8Srgb;
   }
 }
@@ -30,6 +31,7 @@ inline auto convert(vk::Format fmt) -> gfx::ImageFormat {
     case vk::Format::eB8G8R8A8Srgb: return gfx::ImageFormat::BGRA8;
     case vk::Format::eR32G32B32A32Sfloat: return gfx::ImageFormat::RGBA32F;
     case vk::Format::eD24UnormS8Uint: return gfx::ImageFormat::Depth;
+    case vk::Format::eR8Srgb : return gfx::ImageFormat::R8;
     default: return gfx::ImageFormat::RGBA8;
   }
 }
@@ -37,7 +39,10 @@ inline auto convert(vk::Format fmt) -> gfx::ImageFormat {
 inline auto size_from_format(gfx::ImageFormat fmt) -> size_t {
   switch(fmt) {
     case gfx::ImageFormat::Depth : return sizeof(float);
+    case gfx::ImageFormat::RGB32F : return sizeof(float) * 3;
     case gfx::ImageFormat::RGBA32F : return sizeof(float) * 4;
+    case gfx::ImageFormat::R8 : return 1;
+    case gfx::ImageFormat::RGB8 : return 3;
     case gfx::ImageFormat::RGBA8 : [[fallthrough]];
     case gfx::ImageFormat::BGRA8 : [[fallthrough]];
     default : return 4;
@@ -456,6 +461,7 @@ inline auto usage_from_format(gfx::ImageFormat format) {
   using Usage = vk::ImageUsageFlagBits;
   switch(format) {
     case gfx::ImageFormat::Depth: return Usage::eDepthStencilAttachment | Usage::eTransferSrc | Usage::eTransferDst;
+    case gfx::ImageFormat::R8 : return Usage::eTransferSrc | Usage::eTransferDst | Usage::eSampled;
     default : return standard_image_usage();
   }
 }


### PR DESCRIPTION
* Fix vec2 math & union usage
* Add strings to events so on text input the user can read text input.
* Add empty() function to gpu Vector to closer match std::vector :)
* Add support for R8 format images (used for text bitmaps)

See https://github.com/JordanHendl/playground/tree/main/text_rendering for example